### PR TITLE
Test super assignment

### DIFF
--- a/.checkstyle_checks.xml
+++ b/.checkstyle_checks.xml
@@ -12,7 +12,6 @@
   <property name="severity" value="error"/>
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
-    <module name="FileContentsHolder"/>
     <module name="JavadocStyle">
       <property name="checkHtml" value="false"/>
     </module>
@@ -137,13 +136,23 @@
       <property name="format" value=" ,"/>
       <property name="message" value="illegal space before a comma"/>
       <property name="ignoreComments" value="true"/>
-      <metadata name="com.atlassw.tools.eclipse.checkstyle.customMessage" value="Illegal whitespace before a comma."/>
       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Checks for whitespace before a comma."/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.customMessage" value="Illegal whitespace before a comma."/>
     </module>
     <module name="RegexpSinglelineJava">
       <metadata name="net.sf.eclipsecs.core.comment" value="needs a space after comment start"/>
       <property name="format" value="[^:&quot;]//[^&quot;\s]"/>
       <property name="message" value="needs a space after comment start"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="sysout"/>
+      <property name="format" value="System\.(out|err)\.print"/>
+      <property name="message" value="System\.(out|err)\.print should be avoided. Use a logging method instead."/>
+    </module>
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="Checkstyle: stop"/>
+      <property name="onCommentFormat" value="Checkstyle: resume"/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks"/>
     </module>
   </module>
   <module name="SuppressionFilter">
@@ -161,79 +170,10 @@
   <module name="NewlineAtEndOfFile">
     <property name="lineSeparator" value="lf"/>
   </module>
-  <module name="Translation"/>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop constant name check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume constant name check"/>
-    <property name="checkFormat" value="ConstantNameCheck"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Allow non-conforming constant names"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop method name check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume method name check"/>
-    <property name="checkFormat" value="MethodName"/>
-    <property name="checkC" value="false"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable method name checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop parameter assignment check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume parameter assignment check"/>
-    <property name="checkFormat" value="ParameterAssignment"/>
-    <property name="checkC" value="false"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable Parameter Assignment"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop final variable check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume final variable check"/>
-    <property name="checkFormat" value="FinalLocalVariable"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable final variable checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop"/>
-    <property name="onCommentFormat" value="Checkstyle: resume"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="// START GENERATED RAW ASSEMBLER METHODS"/>
-    <property name="onCommentFormat" value="// END GENERATED RAW ASSEMBLER METHODS"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks for generated raw assembler methods"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="// START GENERATED LABEL ASSEMBLER METHODS"/>
-    <property name="onCommentFormat" value="// END GENERATED LABEL ASSEMBLER METHODS"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks for generated label assembler methods"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop inner assignment check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume inner assignment check"/>
-    <property name="checkFormat" value="InnerAssignment"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable inner assignment checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="Checkstyle: stop field name check"/>
-    <property name="onCommentFormat" value="Checkstyle: resume field name check"/>
-    <property name="checkFormat" value="MemberName"/>
-    <property name="checkC" value="false"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable field name checks"/>
-  </module>
   <module name="RegexpMultiline">
     <metadata name="net.sf.eclipsecs.core.comment" value="illegal Windows line ending"/>
     <property name="format" value="\r\n"/>
     <property name="message" value="illegal Windows line ending"/>
   </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop system..print check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume system..print check"/>
-    <property name="checkFormat" value="RegexpSingleline"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable System.(out|err).print checks"/>
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CheckStyle: stop header check"/>
-    <property name="onCommentFormat" value="CheckStyle: resume header check"/>
-    <property name="checkFormat" value=".*Header"/>
-    <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable header checks"/>
-  </module>
-  <module name="RegexpSingleline">
-    <property name="format" value="System\.(out|err)\.print"/>
-  </module>
+  <module name="Translation"/>
 </module>

--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
     <property name="classes.dir" value="${build.dir}/classes"/>
     <property name="junit.version" value="4.12" />
 
-    <property name="checkstyle.version" value="7.8.1" />
+    <property name="checkstyle.version" value="8.14" />
 
     <property environment="env"/>
 
@@ -67,9 +67,9 @@
 
     <target name="checkstyle-jar">
         <mkdir dir="${lib.dir}" />
-        <get src="http://tenet.dl.sourceforge.net/project/checkstyle/checkstyle/${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
-            usetimestamp="true"
-            dest="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
+        <get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
+             usetimestamp="true"
+             dest="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
     </target>
     
     <target name="checkstyle" depends="checkstyle-jar" description="Check Code with Checkstyle">

--- a/src/som/compiler/ClassGenerationContext.java
+++ b/src/som/compiler/ClassGenerationContext.java
@@ -107,7 +107,7 @@ public class ClassGenerationContext {
     return classSide;
   }
 
-  public som.vmobjects.SClass assemble() {
+  public som.vmobjects.SClass assemble() throws ProgramDefinitionError {
     // build class class name
     String ccname = name.getEmbeddedString() + " class";
 

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -231,7 +231,7 @@ public class Parser {
     expect(EndTerm);
   }
 
-  private void superclass(final ClassGenerationContext cgenc) {
+  private void superclass(final ClassGenerationContext cgenc) throws ProgramDefinitionError {
     SSymbol superName;
     if (sym == Identifier) {
       superName = universe.symbolFor(text);
@@ -929,7 +929,7 @@ public class Parser {
   }
 
   private void genPopVariable(final MethodGenerationContext mgenc,
-      final String var) {
+      final String var) throws ParseError {
     // The purpose of this function is to find out whether the variable to be
     // popped off the stack is a local variable, argument, or object field.
     // This is done by examining all available lexical contexts, starting with
@@ -946,7 +946,12 @@ public class Parser {
         bcGen.emitPOPLOCAL(mgenc, tri.getX(), tri.getY());
       }
     } else {
-      bcGen.emitPOPFIELD(mgenc, universe.symbolFor(var));
+      SSymbol varName = universe.symbolFor(var);
+      if (!mgenc.hasField(varName)) {
+        throw new ParseError("Trying to write to field with the name '" + var
+            + "', but field does not seem exist in class.", Symbol.NONE, this);
+      }
+      bcGen.emitPOPFIELD(mgenc, varName);
     }
   }
 

--- a/src/som/interpreter/Interpreter.java
+++ b/src/som/interpreter/Interpreter.java
@@ -25,6 +25,7 @@
 
 package som.interpreter;
 
+import som.compiler.ProgramDefinitionError;
 import som.vm.Universe;
 import som.vmobjects.SAbstractObject;
 import som.vmobjects.SBlock;
@@ -72,7 +73,7 @@ public class Interpreter {
     getFrame().push(((SObject) getSelf()).getField(fieldIndex));
   }
 
-  private void doPushBlock(final int bytecodeIndex) {
+  private void doPushBlock(final int bytecodeIndex) throws ProgramDefinitionError {
     // Handle the PUSH BLOCK bytecode
     SMethod blockMethod = (SMethod) getMethod().getConstant(bytecodeIndex);
 
@@ -215,7 +216,7 @@ public class Interpreter {
     send(signature, receiver.getSOMClass(universe), bytecodeIndex);
   }
 
-  public SAbstractObject start() {
+  public SAbstractObject start() throws ProgramDefinitionError {
     // Iterate through the bytecodes
     while (true) {
 

--- a/src/som/primitives/SystemPrimitives.java
+++ b/src/som/primitives/SystemPrimitives.java
@@ -24,12 +24,13 @@
 
 package som.primitives;
 
-import som.interpreter.Interpreter;
+import som.compiler.ProgramDefinitionError;
 import som.interpreter.Frame;
+import som.interpreter.Interpreter;
 import som.vm.Universe;
+import som.vmobjects.SAbstractObject;
 import som.vmobjects.SClass;
 import som.vmobjects.SInteger;
-import som.vmobjects.SAbstractObject;
 import som.vmobjects.SPrimitive;
 import som.vmobjects.SString;
 import som.vmobjects.SSymbol;
@@ -47,7 +48,12 @@ public class SystemPrimitives extends Primitives {
       public void invoke(final Frame frame, final Interpreter interpreter) {
         SSymbol argument = (SSymbol) frame.pop();
         frame.pop(); // not required
-        SClass result = universe.loadClass(argument);
+        SClass result = null;
+        try {
+          result = universe.loadClass(argument);
+        } catch (ProgramDefinitionError e) {
+          universe.errorExit(e.toString());
+        }
         frame.push(result != null ? result : universe.nilObject);
       }
     });

--- a/src/som/vm/Universe.java
+++ b/src/som/vm/Universe.java
@@ -60,13 +60,17 @@ public class Universe {
     Universe u = new Universe();
 
     // Start interpretation
-    u.interpret(arguments);
+    try {
+      u.interpret(arguments);
+    } catch (ProgramDefinitionError e) {
+      u.errorExit(e.toString());
+    }
 
     // Exit with error code 0
     u.exit(0);
   }
 
-  public SAbstractObject interpret(String[] arguments) {
+  public SAbstractObject interpret(String[] arguments) throws ProgramDefinitionError {
     // Check for command line switches
     arguments = handleArguments(arguments);
 
@@ -260,9 +264,10 @@ public class Universe {
    * @param className
    * @param selector
    * @return
+   * @throws ProgramDefinitionError
    */
   public SAbstractObject interpret(final String className,
-      final String selector) {
+      final String selector) throws ProgramDefinitionError {
     initializeObjectSystem();
 
     SClass clazz = loadClass(symbolFor(className));
@@ -274,7 +279,7 @@ public class Universe {
     return interpretMethod(clazz, initialize, null);
   }
 
-  private SAbstractObject initialize(final String[] arguments) {
+  private SAbstractObject initialize(final String[] arguments) throws ProgramDefinitionError {
     SAbstractObject systemObject = initializeObjectSystem();
 
     // Start the shell if no filename is given
@@ -305,7 +310,7 @@ public class Universe {
   }
 
   private SAbstractObject interpretMethod(final SAbstractObject receiver,
-      final SInvokable invokable, final SArray arguments) {
+      final SInvokable invokable, final SArray arguments) throws ProgramDefinitionError {
     SMethod bootstrapMethod = createBootstrapMethod();
 
     // Create a fake bootstrap frame with the system object on the stack
@@ -323,7 +328,7 @@ public class Universe {
     return interpreter.start();
   }
 
-  private SAbstractObject initializeObjectSystem() {
+  private SAbstractObject initializeObjectSystem() throws ProgramDefinitionError {
     // Allocate the nil object
     nilObject = new SObject(null);
 
@@ -445,7 +450,8 @@ public class Universe {
     return result;
   }
 
-  public SBlock newBlock(final SMethod method, final Frame context, final int arguments) {
+  public SBlock newBlock(final SMethod method, final Frame context, final int arguments)
+      throws ProgramDefinitionError {
     // Allocate a new block and set its class to be the block class
     SBlock result = new SBlock(method, context, getBlockClass(arguments));
     return result;
@@ -609,7 +615,7 @@ public class Universe {
     return blockClass;
   }
 
-  public SClass getBlockClass(final int numberOfArguments) {
+  public SClass getBlockClass(final int numberOfArguments) throws ProgramDefinitionError {
     // Compute the name of the block class with the given number of
     // arguments
     SSymbol name = symbolFor("Block"
@@ -635,7 +641,7 @@ public class Universe {
     return result;
   }
 
-  public SClass loadClass(final SSymbol name) {
+  public SClass loadClass(final SSymbol name) throws ProgramDefinitionError {
     // Check if the requested class is already in the dictionary of globals
     if (hasGlobal(name)) {
       return (SClass) getGlobal(name);
@@ -654,7 +660,7 @@ public class Universe {
     return result;
   }
 
-  public void loadSystemClass(final SClass systemClass) {
+  public void loadSystemClass(final SClass systemClass) throws ProgramDefinitionError {
     // Load the system class
     SClass result = loadClass(systemClass.getName(), systemClass);
 
@@ -664,7 +670,8 @@ public class Universe {
     }
   }
 
-  private SClass loadClass(final SSymbol name, final SClass systemClass) {
+  private SClass loadClass(final SSymbol name, final SClass systemClass)
+      throws ProgramDefinitionError {
     // Try loading the class from all different paths
     for (String cpEntry : classPath) {
       try {
@@ -679,8 +686,6 @@ public class Universe {
 
       } catch (IOException e) {
         // Continue trying different paths
-      } catch (ProgramDefinitionError e) {
-        errorExit(e.toString());
       }
     }
 

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -41,7 +41,7 @@ import som.vmobjects.SSymbol;
 @RunWith(Parameterized.class)
 public class BasicInterpreterTests {
 
-  @Parameters
+  @Parameters(name = "{0}.{1} [{index}]")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {"MethodCall", "test", 42, SInteger.class},

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import som.compiler.ProgramDefinitionError;
 import som.vm.Universe;
 import som.vmobjects.SClass;
 import som.vmobjects.SDouble;
@@ -44,6 +45,8 @@ public class BasicInterpreterTests {
   @Parameters(name = "{0}.{1} [{index}]")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
+        {"Self", "assignSuper", 42, ProgramDefinitionError.class},
+
         {"MethodCall", "test", 42, SInteger.class},
         {"MethodCall", "test2", 42, SInteger.class},
 
@@ -153,12 +156,17 @@ public class BasicInterpreterTests {
   }
 
   @Test
-  public void testBasicInterpreterBehavior() {
+  public void testBasicInterpreterBehavior() throws ProgramDefinitionError {
     Universe u = new Universe(true);
     u.setupClassPath("Smalltalk:TestSuite/BasicInterpreterTests");
 
-    Object actualResult = u.interpret(testClass, testSelector);
-
-    assertEqualsSOMValue(expectedResult, actualResult);
+    try {
+      Object actualResult = u.interpret(testClass, testSelector);
+      assertEqualsSOMValue(expectedResult, actualResult);
+    } catch (ProgramDefinitionError e) {
+      if (resultType != ProgramDefinitionError.class) {
+        throw e;
+      }
+    }
   }
 }

--- a/tests/som/tests/SomTests.java
+++ b/tests/som/tests/SomTests.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import som.compiler.ProgramDefinitionError;
 import som.vm.Universe;
 
 
@@ -76,7 +77,7 @@ public class SomTests {
   }
 
   @Test
-  public void testSomeTest() {
+  public void testSomeTest() throws ProgramDefinitionError {
     String[] args = {"-cp", "Smalltalk", "TestSuite/TestHarness.som", testName};
 
     // Create Universe

--- a/tests/som/tests/SomTests.java
+++ b/tests/som/tests/SomTests.java
@@ -36,7 +36,7 @@ import som.vm.Universe;
 @RunWith(Parameterized.class)
 public class SomTests {
 
-  @Parameters
+  @Parameters(name = "{0} [{index}]")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {"Array"},


### PR DESCRIPTION
This PR fixes an array out of bounds access to when trying to assign `super`.

Since `super` is a pseudo variable, it's not assignable.
With this change, we at least get an error that we can't try to store into a non-existing object field.

It also updates the SOM core-lib with tests to ensure the desired semantics.

This PR also update Checkstyle after it moved to GitHub and became unavailable.