### PR TITLE
Make som.sh robust to spaces and jar not being built

### DIFF
--- a/som.sh
+++ b/som.sh
@@ -3,4 +3,4 @@ pushd `dirname $0` > /dev/null
 SCRIPT_PATH=`pwd`
 popd > /dev/null
 
-java -server -cp ${SCRIPT_PATH}/build/som.jar som.vm.Universe "$@"
+java -server -cp "${SCRIPT_PATH}/build/classes":"${SCRIPT_PATH}/build/som.jar" som.vm.Universe "$@"


### PR DESCRIPTION
- use quotes to delimit path elements
- add build/classes to avoid having to run `ant jar`
