### PR TITLE
Added String isWhiteSpace, isLetters, and isDigits primitives

### DIFF
--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -187,6 +187,7 @@ public class Lexer {
       case 'f': text.append("\f"); break;
       case '\'': text.append('\''); break;
       case '\\': text.append("\\"); break;
+      case '0': text.append("\0"); break;
       // @formatter:on
     }
     bufp++;

--- a/src/som/primitives/StringPrimitives.java
+++ b/src/som/primitives/StringPrimitives.java
@@ -118,5 +118,70 @@ public class StringPrimitives extends Primitives {
       }
     });
 
+    installInstancePrimitive(new SPrimitive("isWhiteSpace", universe) {
+
+      @Override
+      public void invoke(final Frame frame, final Interpreter interpreter) {
+        SString self = (SString) frame.pop();
+        String embedded = self.getEmbeddedString();
+
+        for (int i = 0; i < embedded.length(); i++) {
+          if (!Character.isWhitespace(embedded.charAt(i))) {
+            frame.push(universe.falseObject);
+            return;
+          }
+        }
+
+        if (embedded.length() > 0) {
+          frame.push(universe.trueObject);
+        } else {
+          frame.push(universe.falseObject);
+        }
+      }
+    });
+
+    installInstancePrimitive(new SPrimitive("isLetters", universe) {
+
+      @Override
+      public void invoke(final Frame frame, final Interpreter interpreter) {
+        SString self = (SString) frame.pop();
+        String embedded = self.getEmbeddedString();
+
+        for (int i = 0; i < embedded.length(); i++) {
+          if (!Character.isLetter(embedded.charAt(i))) {
+            frame.push(universe.falseObject);
+            return;
+          }
+        }
+
+        if (embedded.length() > 0) {
+          frame.push(universe.trueObject);
+        } else {
+          frame.push(universe.falseObject);
+        }
+      }
+    });
+
+    installInstancePrimitive(new SPrimitive("isDigits", universe) {
+
+      @Override
+      public void invoke(final Frame frame, final Interpreter interpreter) {
+        SString self = (SString) frame.pop();
+        String embedded = self.getEmbeddedString();
+
+        for (int i = 0; i < embedded.length(); i++) {
+          if (!Character.isDigit(embedded.charAt(i))) {
+            frame.push(universe.falseObject);
+            return;
+          }
+        }
+
+        if (embedded.length() > 0) {
+          frame.push(universe.trueObject);
+        } else {
+          frame.push(universe.falseObject);
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
This is in support of the new primitives for the String class (https://github.com/SOM-st/SOM/pull/30). This supersedes https://github.com/SOM-st/som-java/pull/11
 
The semantics for `isWhiteSpace`, `isLetters`, `isDigits` as identical to what is needed in the parser. Thus, it should be trivial to implement by simply exposing the already existing implementation.

This also added the `\0` handling in the parser.

@ltratt the implementation PR cleaned up.

@sophie-kaleba could you please review this?