### PR TITLE
Handle line endings at string beginnings correctly

### DIFF
--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -210,12 +210,14 @@ public class Lexer {
     bufp++;
 
     while (currentChar() != '\'') {
-      lexStringChar();
       while (endOfBuffer()) {
         if (fillBuffer() == -1) {
           return;
         }
         text.append('\n');
+      }
+      if (currentChar() != '\'') {
+        lexStringChar();
       }
     }
 


### PR DESCRIPTION
This fixes that we miss the end of line, and avoid adding `\0` characters.

The corresponding test is introduced by https://github.com/SOM-st/SOM/pull/32.