### PR TITLE
Fix semantics of empty blocks

### DIFF
--- a/src/som/compiler/MethodGenerationContext.java
+++ b/src/som/compiler/MethodGenerationContext.java
@@ -222,6 +222,10 @@ public class MethodGenerationContext {
     locals.add(local);
   }
 
+  public boolean hasBytecodes() {
+    return !bytecode.isEmpty();
+  }
+
   public void removeLastBytecode() {
     bytecode.remove(bytecode.size() - 1);
   }

--- a/src/som/compiler/MethodGenerationContext.java
+++ b/src/som/compiler/MethodGenerationContext.java
@@ -55,9 +55,10 @@ import som.vmobjects.SSymbol;
 
 public class MethodGenerationContext {
 
-  private ClassGenerationContext      holderGenc;
-  private MethodGenerationContext     outerGenc;
-  private boolean                     blockMethod;
+  private final ClassGenerationContext  holderGenc;
+  private final MethodGenerationContext outerGenc;
+  private final boolean                 blockMethod;
+
   private SSymbol                     signature;
   private final List<String>          arguments = new ArrayList<String>();
   private boolean                     primitive;
@@ -66,8 +67,21 @@ public class MethodGenerationContext {
   private boolean                     finished;
   private final ArrayList<Byte>       bytecode  = new ArrayList<>();
 
-  public void setHolder(final ClassGenerationContext cgenc) {
-    holderGenc = cgenc;
+  /**
+   * Constructor used for block methods.
+   */
+  public MethodGenerationContext(final ClassGenerationContext holderGenc,
+      final MethodGenerationContext outerGenc) {
+    this.holderGenc = holderGenc;
+    this.outerGenc = outerGenc;
+    blockMethod = outerGenc != null;
+  }
+
+  /**
+   * Constructor used for normal methods.
+   */
+  public MethodGenerationContext(final ClassGenerationContext holderGenc) {
+    this(holderGenc, null);
   }
 
   public void addArgument(final String arg) {
@@ -229,16 +243,8 @@ public class MethodGenerationContext {
     return true;
   }
 
-  public void setIsBlockMethod(final boolean isBlock) {
-    blockMethod = isBlock;
-  }
-
   public ClassGenerationContext getHolder() {
     return holderGenc;
-  }
-
-  public void setOuter(final MethodGenerationContext mgenc) {
-    outerGenc = mgenc;
   }
 
   public byte addLiteral(final SAbstractObject lit) {

--- a/src/som/compiler/MethodGenerationContext.java
+++ b/src/som/compiler/MethodGenerationContext.java
@@ -25,11 +25,25 @@
 
 package som.compiler;
 
-import static som.interpreter.Bytecodes.*;
+import static som.interpreter.Bytecodes.DUP;
+import static som.interpreter.Bytecodes.HALT;
+import static som.interpreter.Bytecodes.POP;
+import static som.interpreter.Bytecodes.POP_ARGUMENT;
+import static som.interpreter.Bytecodes.POP_FIELD;
+import static som.interpreter.Bytecodes.POP_LOCAL;
+import static som.interpreter.Bytecodes.PUSH_ARGUMENT;
+import static som.interpreter.Bytecodes.PUSH_BLOCK;
+import static som.interpreter.Bytecodes.PUSH_CONSTANT;
+import static som.interpreter.Bytecodes.PUSH_FIELD;
+import static som.interpreter.Bytecodes.PUSH_GLOBAL;
+import static som.interpreter.Bytecodes.PUSH_LOCAL;
+import static som.interpreter.Bytecodes.RETURN_LOCAL;
+import static som.interpreter.Bytecodes.RETURN_NON_LOCAL;
+import static som.interpreter.Bytecodes.SEND;
+import static som.interpreter.Bytecodes.SUPER_SEND;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import som.vm.Universe;
 import som.vmobjects.SAbstractObject;
@@ -50,7 +64,7 @@ public class MethodGenerationContext {
   private final List<String>          locals    = new ArrayList<String>();
   private final List<SAbstractObject> literals  = new ArrayList<SAbstractObject>();
   private boolean                     finished;
-  private final Vector<Byte>          bytecode  = new Vector<Byte>();
+  private final ArrayList<Byte>       bytecode  = new ArrayList<>();
 
   public void setHolder(final ClassGenerationContext cgenc) {
     holderGenc = cgenc;
@@ -94,7 +108,7 @@ public class MethodGenerationContext {
     int i = 0;
 
     while (i < bytecode.size()) {
-      switch (bytecode.elementAt(i)) {
+      switch (bytecode.get(i)) {
         case HALT:
           i++;
           break;
@@ -131,7 +145,7 @@ public class MethodGenerationContext {
         case SUPER_SEND: {
           // these are special: they need to look at the number of
           // arguments (extractable from the signature)
-          SSymbol sig = (SSymbol) literals.get(bytecode.elementAt(i + 1));
+          SSymbol sig = (SSymbol) literals.get(bytecode.get(i + 1));
 
           depth -= sig.getNumberOfSignatureArguments();
 
@@ -145,7 +159,7 @@ public class MethodGenerationContext {
           break;
         default:
           throw new IllegalStateException("Illegal bytecode "
-              + bytecode.elementAt(i));
+              + bytecode.get(i));
       }
 
       if (depth > maxDepth) {
@@ -195,7 +209,7 @@ public class MethodGenerationContext {
   }
 
   public void removeLastBytecode() {
-    bytecode.removeElementAt(bytecode.size() - 1);
+    bytecode.remove(bytecode.size() - 1);
   }
 
   public boolean isBlockMethod() {

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -202,8 +202,7 @@ public class Parser {
     instanceFields(cgenc);
     while (sym == Identifier || sym == Keyword || sym == OperatorSequence
         || symIn(binaryOpSyms)) {
-      MethodGenerationContext mgenc = new MethodGenerationContext();
-      mgenc.setHolder(cgenc);
+      MethodGenerationContext mgenc = new MethodGenerationContext(cgenc);
       mgenc.addArgument("self");
 
       method(mgenc);
@@ -220,8 +219,7 @@ public class Parser {
       classFields(cgenc);
       while (sym == Identifier || sym == Keyword || sym == OperatorSequence
           || symIn(binaryOpSyms)) {
-        MethodGenerationContext mgenc = new MethodGenerationContext();
-        mgenc.setHolder(cgenc);
+        MethodGenerationContext mgenc = new MethodGenerationContext(cgenc);
         mgenc.addArgument("self");
 
         method(mgenc);
@@ -561,11 +559,7 @@ public class Parser {
         nestedTerm(mgenc);
         break;
       case NewBlock: {
-        MethodGenerationContext bgenc = new MethodGenerationContext();
-        bgenc.setIsBlockMethod(true);
-        bgenc.setHolder(mgenc.getHolder());
-        bgenc.setOuter(mgenc);
-
+        MethodGenerationContext bgenc = new MethodGenerationContext(mgenc.getHolder(), mgenc);
         nestedBlock(bgenc);
 
         SMethod blockMethod = bgenc.assemble(universe);

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -186,6 +186,11 @@ public class Parser {
     getSymbolFromLexer();
   }
 
+  @Override
+  public String toString() {
+    return filename + ":" + lexer.getCurrentLineNumber() + ":" + lexer.getCurrentColumn();
+  }
+
   public void classdef(final ClassGenerationContext cgenc) throws ProgramDefinitionError {
     cgenc.setName(universe.symbolFor(text));
     expect(Identifier);

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -456,6 +456,12 @@ public class Parser {
         // was terminated with a . or not)
         mgenc.removeLastBytecode();
       }
+      if (mgenc.isBlockMethod() && !mgenc.hasBytecodes()) {
+        // if the block is empty, we need to return nil
+        SSymbol nilSym = universe.symbolFor("nil");
+        mgenc.addLiteralIfAbsent(nilSym);
+        bcGen.emitPUSHGLOBAL(mgenc, nilSym);
+      }
       bcGen.emitRETURNLOCAL(mgenc);
       mgenc.setFinished();
     } else if (sym == EndTerm) {
@@ -878,6 +884,12 @@ public class Parser {
     // expression
     // in the block was not terminated by ., and can generate a return
     if (!mgenc.isFinished()) {
+      if (!mgenc.hasBytecodes()) {
+        // if the block is empty, we need to return nil
+        SSymbol nilSym = universe.symbolFor("nil");
+        mgenc.addLiteralIfAbsent(nilSym);
+        bcGen.emitPUSHGLOBAL(mgenc, nilSym);
+      }
       bcGen.emitRETURNLOCAL(mgenc);
       mgenc.setFinished(true);
     }

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -60,9 +60,9 @@ public class BasicInterpreterTests {
         {"Blocks", "testArg2", 77, SInteger.class},
         {"Blocks", "testArgAndLocal", 8, SInteger.class},
         {"Blocks", "testArgAndContext", 8, SInteger.class},
-        {"Blocks", "testEmptyZeroArg",  1, SInteger.class},
-        {"Blocks", "testEmptyOneArg",   1, SInteger.class},
-        {"Blocks", "testEmptyTwoArg",   1, SInteger.class},
+        {"Blocks", "testEmptyZeroArg", 1, SInteger.class},
+        {"Blocks", "testEmptyOneArg", 1, SInteger.class},
+        {"Blocks", "testEmptyTwoArg", 1, SInteger.class},
 
         {"Return", "testReturnSelf", "Return", SClass.class},
         {"Return", "testReturnSelfImplicitly", "Return", SClass.class},

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -113,10 +113,12 @@ public class BasicInterpreterTests {
 
         {"Regressions", "testSymbolEquality", 1, SInteger.class},
         {"Regressions", "testSymbolReferenceEquality", 1, SInteger.class},
+        {"Regressions", "testUninitializedLocal", 1, SInteger.class},
+        {"Regressions", "testUninitializedLocalInBlock", 1, SInteger.class},
 
         {"BinaryOperation", "test", 3 + 8, SInteger.class},
 
-        {"NumberOfTests", "numberOfTests", 52, SInteger.class}
+        {"NumberOfTests", "numberOfTests", 54, SInteger.class}
     });
   }
 

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -60,6 +60,9 @@ public class BasicInterpreterTests {
         {"Blocks", "testArg2", 77, SInteger.class},
         {"Blocks", "testArgAndLocal", 8, SInteger.class},
         {"Blocks", "testArgAndContext", 8, SInteger.class},
+        {"Blocks", "testEmptyZeroArg",  1, SInteger.class},
+        {"Blocks", "testEmptyOneArg",   1, SInteger.class},
+        {"Blocks", "testEmptyTwoArg",   1, SInteger.class},
 
         {"Return", "testReturnSelf", "Return", SClass.class},
         {"Return", "testReturnSelfImplicitly", "Return", SClass.class},
@@ -118,7 +121,7 @@ public class BasicInterpreterTests {
 
         {"BinaryOperation", "test", 3 + 8, SInteger.class},
 
-        {"NumberOfTests", "numberOfTests", 54, SInteger.class}
+        {"NumberOfTests", "numberOfTests", 57, SInteger.class}
     });
   }
 


### PR DESCRIPTION
This PR does make sure that empty blocks evaluate to `nil`.
On the way of getting there, it does a bit more cleanup:

 - make method generation context less mutable
 - add Parser.toString()
 - replace Vector in MethodGenerationContext with an ArrayList (don't need the synchronized)

@sophie-kaleba could you take a look at this one and review/approach it?
I'd assume grSOM will need this update, too.

This addresses https://github.com/SOM-st/SOM/issues/36 and https://github.com/SOM-st/SOM/pull/54.