### PR TITLE
Add more interpreter microbenchmarks

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -65,6 +65,29 @@ benchmark_suites:
             - Recurse:      {extra_args: 1}
             - Mandelbrot:   {extra_args: 3}
 
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        invocations: 5
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead
+            - ArrayReadConst
+            - ArrayWriteConstConst
+            - BlockSend0ConstReturn
+            - Const
+            - FieldConstWrite
+            - FieldRead
+            - FieldReadIncWrite
+            - FieldReadWrite
+            - GlobalRead
+            - LocalConstWrite
+            - LocalRead
+            - LocalReadIncWrite
+            - LocalReadWrite
+            - SelfSend0
+            - SelfSend0BlockConstNonLocalReturn
+
 executors:
     som:  {path: ., executable: som.sh}
     somsom:
@@ -80,6 +103,7 @@ experiments:
         suites:
             - micro
             - macro
+            - interpreter
         executions:
             - som
     SomSom:


### PR DESCRIPTION
This updates the core-lib to https://github.com/SOM-st/SOM/pull/121
and adds the benchmarks to the rebench.conf file.