### PR TITLE
Update core-lib and add benchmarks to rebench.conf

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -53,6 +53,9 @@ benchmark_suites:
             - FieldLoop:    {extra_args: 1}
             - WhileLoop:    {extra_args: 10}
             - Mandelbrot:   {extra_args: 30}
+            - IfNil:        {extra_args: 4}
+            - Knapsack:     {extra_args: 5}
+            - VectorBenchmark: {extra_args: 2}
 
     micro-somsom:
         gauge_adapter: RebenchLog


### PR DESCRIPTION
This PR updates the core-lib to the latest version, which includes a few tests and two benchmarks. The benchmarks are added to the benchmarking setup.